### PR TITLE
fix: 本番デプロイ用TypeScriptエラーを修正

### DIFF
--- a/backend/src/@types/express-session.d.ts
+++ b/backend/src/@types/express-session.d.ts
@@ -1,0 +1,11 @@
+import 'express-session';
+import { Session } from 'express-session';
+
+declare module 'express' {
+  interface Request {
+    sessionID?: string;
+    session?: Session & Partial<any>;
+  }
+}
+
+export {};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,8 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+// セッション型定義はd.tsファイルで自動読み込み
+
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -131,7 +133,7 @@ if (process.env.NODE_ENV === 'production') {
       console.log('🔍 Twitter OAuth Request:', {
         method: req.method,
         path: req.path,
-        sessionID: req.sessionID,
+        sessionID: req.sessionID || 'not available',
         sessionExists: !!req.session,
         sessionData: req.session ? Object.keys(req.session) : 'no session',
         cookies: req.headers.cookie ? 'present' : 'missing'

--- a/backend/src/middleware/unifiedAuth.ts
+++ b/backend/src/middleware/unifiedAuth.ts
@@ -25,6 +25,9 @@ export const authenticateUnifiedToken = async (req: Request, res: Response, next
 
     try {
       // Try Firebase token first
+      if (!adminAuth) {
+        throw new Error('Firebase admin not configured');
+      }
       const decodedToken = await adminAuth.verifyIdToken(token);
       
       // Get user from database using Firebase UID
@@ -90,6 +93,9 @@ export const optionalUnifiedAuth = async (req: Request, res: Response, next: Nex
 
     try {
       // Try Firebase token first
+      if (!adminAuth) {
+        throw new Error('Firebase admin not configured');
+      }
       const decodedToken = await adminAuth.verifyIdToken(token);
       
       user = await prisma.user.findUnique({


### PR DESCRIPTION
- express-session型定義を追加（sessionIDとsessionプロパティ）
- unifiedAuth.tsのadminAuth null チェック追加
- 型定義ファイルを@typesディレクトリに配置
- TypeScript compilation完全クリア

🤖 Generated with [Claude Code](https://claude.ai/code)